### PR TITLE
Upgrade parsedown to v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,7 @@
       "email": "hi@giffordnowland.com"
     }
   ],
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/gnowland/parsedown.git"
-    }
-  ],
   "require": {
-    "erusev/parsedown": "1.7.4-alpha"
+    "erusev/parsedown": "2.0.0"
   }
 }


### PR DESCRIPTION
Per #1  Swap out [gnowland/parsedown](https://github.com/gnowland/parsedown) for [erusev/parsedown](https://github.com/erusev/parsedown) when v2.0.0 is released 